### PR TITLE
Added proper Docker image building to resolve the missing duckdb module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: help setup lint test data-dirs setup-env airflow-up airflow-down airflow-reset fix-permissions
+.PHONY: help setup lint test data-dirs setup-env airflow-up airflow-down airflow-build airflow-reset fix-permissions
 
 help:
-	@echo "Targets: setup | lint | test | data-dirs | setup-env | airflow-up | airflow-down | airflow-reset | fix-permissions"
+	@echo "Targets: setup | lint | test | data-dirs | setup-env | airflow-up | airflow-down | airflow-build | airflow-reset | fix-permissions"
 	@echo "Services: Airflow (8080) | Jupyter (8888)"
 	@echo "DuckDB: Access via Jupyter notebooks at http://localhost:8888"
 	@echo "Permissions: Run 'make fix-permissions' if Jupyter can't access DuckDB files"
@@ -38,6 +38,7 @@ setup-env:
 
 airflow-up:
 	cd docker/airflow && \
+		docker compose build && \
 		docker compose up -d postgres && \
 		docker compose up -d airflow-init && \
 		docker compose up -d airflow-webserver airflow-scheduler airflow-triggerer viewer
@@ -45,8 +46,11 @@ airflow-up:
 airflow-down:
 	cd docker/airflow && docker compose down
 
+airflow-build:
+	cd docker/airflow && docker compose build --no-cache
+
 airflow-reset:
-	cd docker/airflow && docker compose down -v && docker compose up -d postgres && docker compose up -d airflow-init && docker compose up -d airflow-webserver airflow-scheduler airflow-triggerer viewer
+	cd docker/airflow && docker compose down -v && docker compose build && docker compose up -d postgres && docker compose up -d airflow-init && docker compose up -d airflow-webserver airflow-scheduler airflow-triggerer viewer
 
 fix-permissions:
 	@echo "🔧 Fixing DuckDB permissions for Jupyter access..."


### PR DESCRIPTION
This will:
  1. Build the custom Airflow image with all requirements.txt dependencies
  2. Start services with the properly configured containers
  3. The DAG will now be able to import duckdb successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an airflow-build command to build Airflow images without cache.
  * Help output now lists the new airflow-build command.

* **Chores**
  * airflow-up now performs a build step before starting services.
  * airflow-reset now rebuilds before recreating services to ensure fresh images.
  * Updated command declarations to include the new airflow-build in the available targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->